### PR TITLE
Fix: Remove test execution from deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,15 +17,11 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dependencies
+      - name: Build package
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-
-      - name: Run tests
-        run: |
-          pip install -e .[test]
-          pytest
+          python -m pip install build
+          python -m build
 
       - name: Install Railway CLI
         run: |


### PR DESCRIPTION
## Description
This PR addresses issue #37 by removing test execution from the deployment workflow and focusing solely on package building and deployment to Railway.

## Changes Made
- ✅ Removed `pytest` execution step from the deployment workflow
- ✅ Replaced dependency installation with proper package building using `python -m build`
- ✅ Streamlined workflow to focus only on building and deployment
- ✅ Maintained Railway CLI installation and deployment steps

## Benefits
- 🚀 Faster deployment process (no test execution overhead)
- 📦 Proper package building using Python standard tools
- 🎯 Clear separation of concerns (testing vs deployment)
- ⚡ Reduced workflow complexity

## Testing
The workflow changes have been reviewed and the package building approach follows Python packaging best practices using the `build` module.

Fixes #37