### PR TITLE
Release: Bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI/CD workflows
 - Comprehensive documentation
 - Modern Python dependencies (FastAPI 0.115.12, Uvicorn 0.34.3, Python 3.12+)
+## v0.1.1 (2025-08-11)
+
 ## v0.1.0 (2025-08-11)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "6mlet-tech-challenge-01"
 description = "FastAPI application for 6MLET Tech Challenge 01"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     {name = "Fabricio Entringer", email = "fabricio@entringer.dev"},
     {name = "Adriano Ribeiro", email = "aribeiro@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ version_scheme = "semver"
 version_provider = "commitizen"
 update_changelog_on_bump = true
 major_version_zero = true
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## 🚀 Version Bump: 0.1.0 → 0.1.1

This PR bumps the project version from 0.1.0 to 0.1.1 (PATCH release).

### Changes Made
- ✅ Updated version in `pyproject.toml` (project section)
- ✅ Updated version in `pyproject.toml` (commitizen section)
- ✅ Updated `CHANGELOG.md` with new version entry
- ✅ Created git tag `v0.1.1`

### Commits
- `bump: version 0.1.0 → 0.1.1` - Automated version bump by commitizen
- `fix: sync project version with commitizen version (0.1.1)` - Ensured both version fields are consistent

### Verification
The application's `get_version()` function will now return `"0.1.1"` when called.

Ready for merge into `develop` branch.